### PR TITLE
docs: update learn series and README with GitLab CLI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,18 @@ A production-ready `.github/` configuration that turns GitHub Copilot into a str
 - 8 specialist agents (Discuss, Research, Planner, TDD, Reviewer, Verify, ApiBuilder, ParallelBuilder)
 - 15 slash command prompts (`/start-issue`, `/discuss`, `/research`, `/plan`, `/execute`, `/verify`, `/debug`, `/add-new-api`, `/finish-branch`, `/generate-api-doc`, `/update-api-doc`, `/receive-review`, `/status`, `/sync-docs`, `/summarize`)
 - Auto-loading instructions per file type (architecture rules, commenting standards, doc-on-change)
-- 11 auto-loading skills (TDD, doc-reviewer, GitHub CLI workflow, Playwright, code review patterns)
+- 13 auto-loading skills (TDD, doc-reviewer, GitHub CLI workflow, GitLab CLI workflow, Playwright, code review patterns)
 - Playwright testing skills and instructions
 - Session hooks (auto-commit + structured activity log)
 - 9 documentation templates + 7 codebase knowledge templates
 - GitHub CLI integration (automatic issue/PR creation and merge)
+- GitLab CLI integration (automatic issue/MR creation and merge)
 - Work folder structure (`work/ISSUE-XXX-name/`) to prevent merge conflicts
 - Activity logging (`logs/copilot/agent-activity.log`) for audit trail
 - Dual-mode execution (Agent Mode for complex features, TDD Agent for routine work)
 - A 11-part beginner-friendly learn series in `learn/` (at repo root — not copied on install)
 
-> **What's New in V2** (March 2026): Work folder structure, GitHub CLI integration, dual-mode execution, fixed agent handoff chain, activity logging. See [MIGRATION-V2.md](./docs/MIGRATION-V2.md) for upgrade guide.
+> **What's New in V2** (March 2026): Work folder structure, GitHub and GitLab CLI integration, dual-mode execution, fixed agent handoff chain, activity logging. See [MIGRATION-V2.md](./docs/MIGRATION-V2.md) for upgrade guide.
 
 > **Learn more**: Start with [`learn/00-introduction.md`](./learn/00-introduction.md) or read it as a website: **[srisatyalokesh.github.io/copilot-team-workflow](https://srisatyalokesh.github.io/copilot-team-workflow)**
 
@@ -176,12 +177,13 @@ Everything else works out of the box.
 │   └── sync-docs.prompt.md              ← /sync-docs (bulk doc updates)
 ├── workflows/                           ← Specialist workflows
 │   └── acquire-codebase-knowledge.md    ← Factual codebase mapping procedure
-├── skills/                              ← 11 auto-loading knowledge packs
+├── skills/                              ← 13 auto-loading knowledge packs
 │   ├── acquire-codebase-knowledge/SKILL.md ← Factual codebase mapping (Arch, Stack, etc.)
 │   ├── agent-activity-logger/SKILL.md   ← Log format reference
 │   ├── doc-reviewer/SKILL.md            ← Brutal doc review (Critical/Major/Minor)
 │   ├── documentation-writer/SKILL.md    ← Diátaxis-guided doc creation
-│   ├── github-cli-workflow/SKILL.md     ← GitHub issue/PR automation patterns
+│   ├── github-cli-workflow/SKILL.md     ← GitHub issue/PR automation (gh CLI)
+│   ├── gitlab-cli-workflow/SKILL.md     ← GitLab issue/MR automation (glab CLI)
 │   ├── playwright-automation-fill-in-form/SKILL.md
 │   ├── playwright-explore-website/SKILL.md
 │   ├── playwright-generate-test/SKILL.md

--- a/learn/01-github-folder-explained.md
+++ b/learn/01-github-folder-explained.md
@@ -176,6 +176,8 @@ A skill is a folder containing a `SKILL.md` — a detailed reference document th
 ├── agent-activity-logger/SKILL.md        ← Log format for session audit trail
 ├── doc-reviewer/SKILL.md                 ← Brutal doc review (Critical/Major/Minor + score)
 ├── documentation-writer/SKILL.md         ← Diátaxis-guided doc creation (4 types)
+├── github-cli-workflow/SKILL.md          ← gh CLI: issues, PRs, branches, merge patterns
+├── gitlab-cli-workflow/SKILL.md          ← glab CLI: issues, MRs, branches, merge patterns
 ├── playwright-automation-fill-in-form/SKILL.md ← Automate form fill via Playwright MCP
 ├── playwright-explore-website/SKILL.md   ← Explore URL, find 3-5 flows, propose tests
 ├── playwright-generate-test/SKILL.md     ← Generate TypeScript Playwright spec

--- a/learn/02-five-phase-workflow.md
+++ b/learn/02-five-phase-workflow.md
@@ -58,8 +58,8 @@ The 5-phase workflow prevents this. Every piece of work — feature, bug fix, im
 3. If B: `git checkout <primary> && git pull origin <primary> && git checkout -b <type>/[issue-id]-[slug]`
 4. Runs `npm test` — confirms baseline is green before any new work
 5. Creates work folder at `work/ISSUE-[id]-[slug]/` with `plan.md` and `result.md` templates
-6. (If GitHub repo) Offers to create GitHub issue with `gh issue create`
-7. (If GitHub repo) Offers to create feature branch
+6. (If GitHub/GitLab repo) Offers to create a tracker issue (`gh issue create` / `glab issue create`)
+7. Offers to create feature branch
 8. Appends entry to `logs/copilot/agent-activity.log`
 9. Hands off to the **Discuss** agent automatically
 
@@ -67,7 +67,7 @@ The 5-phase workflow prevents this. Every piece of work — feature, bug fix, im
 
 > **Why A/B choice?** If you're mid-way through a feature and just want to continue, you don't want `/start-issue` forcing a new branch. Option A lets you keep context; Option B is for truly new work.
 
-**Output**: Primary branch confirmed, feature branch ready, work folder created at `work/ISSUE-XXX-name/`, GitHub issue created (optional), activity logged, Discuss begins
+**Output**: Primary branch confirmed, feature branch ready, work folder created at `work/ISSUE-XXX-name/`, tracker issue created (optional), activity logged, Discuss begins
 
 ---
 
@@ -76,16 +76,18 @@ The 5-phase workflow prevents this. Every piece of work — feature, bug fix, im
 **Goal**: Write down requirements everyone agrees on, before anyone touches code.
 
 **What happens**:
-1. Discuss agent asks clarifying questions (one at a time, max 5)
-2. Proposes 2-3 approaches with trade-offs
-3. Gets explicit approval on final design
-4. Writes Phase 1 (Requirements) in `work/ISSUE-XXX-name/plan.md`
-5. Marks Phase 1 as `[x] Complete`
-6. Appends entry to `logs/copilot/agent-activity.log`
-7. Shows full 5-phase roadmap
-8. Hands off to Research agent **automatically**
+1. Detects Git provider (GitHub or GitLab) from remote URL — asks to confirm once, stores result in `copilot-instructions.md` permanently
+2. Loads the appropriate CLI skill (`github-cli-workflow` or `gitlab-cli-workflow`)
+3. Asks clarifying questions (one at a time, max 5)
+4. Proposes 2-3 approaches with trade-offs
+5. Gets explicit approval on final design
+6. Writes Phase 1 (Requirements) in `work/ISSUE-XXX-name/plan.md`
+7. Marks Phase 1 as `[x] Complete`
+8. Appends entry to `logs/copilot/agent-activity.log`
+9. Shows full 5-phase roadmap
+10. Hands off to Research agent **automatically**
 
-**Output**: `plan.md` Phase 1 complete, Research starts automatically
+**Output**: `plan.md` Phase 1 complete, Git provider stored, Research starts automatically
 
 ---
 
@@ -201,6 +203,7 @@ Window: 15 min (not 5 — confirmed with product team in Discuss phase).
    - Updates `work/ISSUE-XXX-name/result.md` Phase 4
    - Marks Phase 4 as `[x] Complete`
    - (If GitHub repo) Offers to create PR with `gh pr create --title "<type>: <title>" --body "Fixes #XX\n\n<summary>"`
+   - (If GitLab repo) Offers to create MR with `glab mr create --title "<type>: <title>" --description "Closes #XX\n\n<summary>"`
    - Appends entry to `logs/copilot/agent-activity.log`
    - Completes with message: **"Run `/verify work/ISSUE-XXX-name` for quality gate"**
 
@@ -210,7 +213,7 @@ feat: rate limit middleware Fixes #42
 feat: admin bypass for rate limit Fixes #42
 ```
 
-**Why GitHub issue reference?** Links commits to the GitHub issue for traceability.
+**Why issue reference in commits?** Links commits to the tracker issue for traceability — works on both GitHub and GitLab.
 
 **Copilot updates**:
 - `work/ISSUE-042-login-rate-limiting/result.md` → Phase 4 execution notes
@@ -242,7 +245,8 @@ feat: admin bypass for rate limit Fixes #42
 6. Appends entry to `logs/copilot/agent-activity.log`
 7. If verdict is **✅ READY**:
    - (If GitHub repo + PR exists) Offers to merge PR with `gh pr merge --squash --delete-branch`
-   - (If GitHub repo + no PR) Offers to create and merge PR
+   - (If GitLab repo + MR exists) Offers to merge MR with `glab mr merge --squash --remove-source-branch`
+   - (If no PR/MR exists) Offers to create and merge one
 8. If verdict is **⛔ NOT READY**:
    - Lists blocking issues
    - Developer fixes issues, then re-runs `/verify`
@@ -274,16 +278,16 @@ Verdict: ✅ READY
 
 **What it does**:
 1. Reads `result.md` Phase 5 verification report
-2. (If GitHub repo) Checks if PR exists with `gh pr view`
+2. Checks if PR/MR exists (`gh pr view` for GitHub, `glab mr view` for GitLab)
 3. Presents 4 options:
    - **Merge to primary locally** — merge the branch into your primary branch (e.g. `dev`)
-   - **Push and create a PR** — push branch and open a GitHub PR (if GitHub repo)
+   - **Push and create a PR/MR** — push branch and open a GitHub PR or GitLab MR
    - **Keep as-is** — preserve the branch and work folder, handle merging later
    - **Discard** — delete the branch and work folder (asks for typed confirmation first)
-4. (If GitHub repo) Uses `gh pr merge` or `gh pr create` automatically
+4. Uses `gh pr merge`/`gh pr create` (GitHub) or `glab mr merge`/`glab mr create` (GitLab) automatically
 5. Archives work folder to `work/.archived/ISSUE-XXX-name/` after merge (optional)
 
-> **Why use `/finish-branch` instead of just running `git merge`?** GitHub integration is handled automatically, and verification report is reviewed one final time before merge.
+> **Why use `/finish-branch` instead of just running `git merge`?** Provider CLI integration is handled automatically, and the verification report is reviewed one final time before merge.
 
 ---
 

--- a/learn/05-daily-workflow.md
+++ b/learn/05-daily-workflow.md
@@ -42,13 +42,13 @@ This is always the first action. Enter the issue description and issue ID when p
 - If B: pull the latest from primary and create `<type>/042-login-rate-limiting`
 - Run `npm test` to confirm baseline is green
 - Create the work folder at `work/ISSUE-042-login-rate-limiting/` with `plan.md` and `result.md` templates
-- (If GitHub repo) Offer to create GitHub issue with `gh issue create`
+- (If GitHub/GitLab repo) Offer to create a tracker issue (`gh`/`glab` issue create)
 - Append entry to `logs/copilot/agent-activity.log`
 - Hand off to the **Discuss** agent
 
 > **Never manually `git checkout -b` before defining requirements.** Let `/start-issue` create the branch — it ensures you're always branching from the freshest version of your primary branch.
 
-**Step 2**: The **Discuss** agent defines requirements
+**Step 2**: The **Discuss** agent detects your Git provider and defines requirements
 
 ```
 "We need to add rate limiting to the login endpoint.
@@ -80,6 +80,7 @@ The Verify agent checks all requirements, tests, and docs — pass/fail report. 
 **Step 7**: Fix anything caught, then use `/finish-branch` to merge or create PR.
 
 If GitHub repo: Offers to merge PR automatically with `gh pr merge`.
+If GitLab repo: Offers to merge MR automatically with `glab mr merge`.
 
 ---
 
@@ -154,7 +155,7 @@ Updated:
 - work/ISSUE-042-login-rate-limiting/result.md (Phase 4 progress)
 ```
 
-Code and docs in the **same commit**, always. GitHub issue reference links commit to issue.
+Code and docs in the **same commit**, always. Issue reference links commit to the tracker issue.
 
 ---
 
@@ -176,8 +177,8 @@ Before you create a PR, run the `/review` command. This dispatches a specialized
 
 1. Run `/verify` — get the verification report
 2. Fix every ❌ item the Verify agent found
-3. Run `/finish-branch` — it re-runs tests, checks lint + TypeScript, confirms requirements, then presents options: **Merge locally / Push PR / Keep as-is / Discard**
-4. For PR option: `gh pr create` is run automatically with a description from the Issue doc
+3. Run `/finish-branch` — it re-runs tests, checks lint + TypeScript, confirms requirements, then presents options: **Merge locally / Push PR⁠/⁠MR / Keep as-is / Discard**
+4. For PR/MR option: `gh pr create` (GitHub) or `glab mr create` (GitLab) is run automatically with a description from the Issue doc
 5. Request a teammate to review
 
 The reviewer runs `/code-review` on the PR files for a systematic multi-dimension review.

--- a/learn/08-boilerplate-setup.md
+++ b/learn/08-boilerplate-setup.md
@@ -21,7 +21,7 @@ This repository is a **ready-to-use boilerplate** for setting up GitHub Copilot 
 - 9 instruction files (developer guide, API architecture, backend, frontend, testing, Playwright, commenting, doc-sync, parallel-agents)
 - 14 prompt slash commands (/start-issue, /discuss, /research, /plan, /execute, /verify, /debug, /add-new-api, /receive-review, /finish-branch, /generate-api-doc, /update-api-doc, /status, /sync-docs)
 - 2 automation hooks (session-auto-commit, session-logger)
-- 10 skills (TDD, subagent-driven-dev, Playwright × 3, code review × 2, doc-reviewer, documentation-writer, activity-logger)
+- 13 skills (TDD, subagent-driven-dev, Playwright × 3, code review × 2, doc-reviewer, documentation-writer, activity-logger, acquire-codebase-knowledge, GitHub CLI workflow, GitLab CLI workflow)
 - 9 documentation templates (Issue, API doc, wrapper doc, external API, flow, ADR, architecture, project, copilot-instructions)
 - A complete learn series (this series, 11 blog-style guides)
 
@@ -164,7 +164,7 @@ These files require **no changes** and work out of the box:
 | All 15 prompts | Commands work for any project |
 | Both hooks | Shell scripts are project-agnostic |
 | All 9 templates | Generic — fill in per use |
-| All 10 skills | Generic knowledge packs |
+| All 13 skills | Generic knowledge packs |
 | `developer-guide.instructions.md` | Generic developer guide |
 | `learn/` folder (boilerplate root) | The learning series, read before installing |
 
@@ -212,16 +212,19 @@ These files require **no changes** and work out of the box:
 │   ├── summarize.prompt.md              ← works as-is (save session context)
 │   └── sync-docs.prompt.md              ← works as-is (bulk doc updates)
 ├── skills/
-│   ├── agent-activity-logger/SKILL.md   ← works as-is
-│   ├── doc-reviewer/SKILL.md            ← works as-is
-│   ├── documentation-writer/SKILL.md    ← works as-is
+│   ├── acquire-codebase-knowledge/SKILL.md  ← works as-is
+│   ├── agent-activity-logger/SKILL.md       ← works as-is
+│   ├── doc-reviewer/SKILL.md                ← works as-is
+│   ├── documentation-writer/SKILL.md        ← works as-is
+│   ├── github-cli-workflow/SKILL.md         ← works as-is (GitHub: gh issues, PRs, merge)
+│   ├── gitlab-cli-workflow/SKILL.md         ← works as-is (GitLab: glab issues, MRs, merge)
 │   ├── playwright-automation-fill-in-form/SKILL.md ← works as-is
 │   ├── playwright-explore-website/SKILL.md  ← works as-is
 │   ├── playwright-generate-test/SKILL.md    ← works as-is
-│   ├── receiving-code-review/SKILL.md   ← works as-is
-│   ├── requesting-code-review/SKILL.md  ← works as-is
+│   ├── receiving-code-review/SKILL.md       ← works as-is
+│   ├── requesting-code-review/SKILL.md      ← works as-is
 │   ├── subagent-driven-development/SKILL.md ← works as-is
-│   └── test-driven-development/SKILL.md ← works as-is
+│   └── test-driven-development/SKILL.md     ← works as-is
 └── hooks/
     ├── session-auto-commit/             ← works as-is
     └── session-logger/                  ← works as-is


### PR DESCRIPTION
Fixes #3

## Changes
- README: skills 11->13, add gitlab-cli-workflow to file structure, update What's New note
- learn/01: add github-cli-workflow + gitlab-cli-workflow to skills listing
- learn/02: update /start-issue, Discuss, Execute, Verify, /finish-branch for both providers
- learn/05: add glab commands alongside gh throughout daily workflow
- learn/08: fix skills count 10->13, add all missing skills to file structure